### PR TITLE
Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: Status description
     default: by unanimously-approved
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'check-circle'


### PR DESCRIPTION
Hi @SnowCait,

When using the github actions, we're getting warning about the used node version.
![image](https://github.com/snow-actions/unanimously-approved/assets/9052536/16d15bad-1e7b-475c-870b-488b10261c2a)

I tried to bump the version then.